### PR TITLE
Staging 250326

### DIFF
--- a/missile_defense_gym.py
+++ b/missile_defense_gym.py
@@ -14,7 +14,7 @@ MAX_SPEED = 2
 DRONE_RADIUS = 300
 DRONE_SIZE = 20
 NUM_DRONES = 3
-
+NUM_MISSILES = 3
 # Colors
 WHITE = (255, 255, 255)
 RED = (255, 0, 0)
@@ -26,20 +26,37 @@ BASE_HIT_REWARD = -50
 DRONE_HIT_REWARD = 100.0
 STEP_PENALTY = -0.01
 OUT_OF_BOUND_REWARD = -100
+CLOSER_TO_MISSILE_REWARD = 0.0
 
-OBSERVATION_SPACE = gym.spaces.Box(low=np.array(
-    [-1.0, -1.0, 0]), high=np.array([1.0, 1.0, 1500]), dtype=np.float32)
-ACTION_SPACE = gym.spaces.Box(low=-10.0, high=10.0, shape=(2,))
+OBSERVATION_SPACE = gym.spaces.Box(
+    low=np.array([-10, -10, -1.1, -1.1, 0, -1.1, -1.1, 0, -1.1, -1.1, 0]),
+    high=np.array(
+        [
+            SCREEN_WIDTH + 10,
+            SCREEN_HEIGHT + 10,
+            1.1,
+            1.1,
+            1500,
+            1.1,
+            1.1,
+            1500,
+            1.1,
+            1.1,
+            1500,
+        ]
+    ),
+    dtype=np.float32,
+)
+ACTION_SPACE = gym.spaces.Box(low=-5.0, high=5.0, shape=(2,))
 
 
 class MissileDefenseEnv(MultiAgentEnv):
-    def __init__(self,  config=None, render=False, realistic_render=False):
+    def __init__(self, config=None, render=False, realistic_render=False):
         self.render_flag = render
         self.realistic_render = realistic_render
         if self.render_flag:
             pygame.init()
-            self.screen = pygame.display.set_mode(
-                (SCREEN_WIDTH, SCREEN_HEIGHT))
+            self.screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
             if self.realistic_render:
                 self.base_png = pygame.image.load("./pygame_asset/base.png").convert_alpha()
                 self.missile_png = pygame.image.load("./pygame_asset/missile.png").convert_alpha()
@@ -58,38 +75,55 @@ class MissileDefenseEnv(MultiAgentEnv):
         self.agents = [f"drone_{i}" for i in range(NUM_DRONES)]
 
         # Initialize missile
-        if np.random.rand() > 0.5:
-            x = np.random.choice([-MISSILE_SIZE, SCREEN_WIDTH + MISSILE_SIZE])
-            y = np.random.uniform(0, SCREEN_HEIGHT)
-        else:
-            x = np.random.uniform(0, SCREEN_WIDTH)
-            y = np.random.choice([-MISSILE_SIZE, SCREEN_HEIGHT + MISSILE_SIZE])
-        self.missile_pos = np.array([x, y], dtype=np.float32)
-        self.missile_velocity = np.zeros(2, dtype=np.float32)
+        self.missiles_data = {}
+        for missile_id in range(NUM_MISSILES):
+            if np.random.rand() > 0.5:
+                x = np.random.choice([-MISSILE_SIZE, SCREEN_WIDTH + MISSILE_SIZE])
+                y = np.random.uniform(0, SCREEN_HEIGHT)
+            else:
+                x = np.random.uniform(0, SCREEN_WIDTH)
+                y = np.random.choice([-MISSILE_SIZE, SCREEN_HEIGHT + MISSILE_SIZE])
+
+            # Store missile data in the dictionary
+            self.missiles_data[f"missile_{missile_id}"] = {
+                "missile_pos": np.array([x, y], dtype=np.float32),
+                "missile_velocity": np.zeros(2, dtype=np.float32),
+                "missile_acceleration": np.random.uniform(0, MAX_ACCELERATION),
+                "neutralized": False,
+            }
 
         # Initialize drones in a circle around the base
         self.drones_pos = {
-            agent: self.base_pos + DRONE_RADIUS *
-            np.array([np.cos(theta), np.sin(theta)])
+            agent: self.base_pos + DRONE_RADIUS * np.array([np.cos(theta), np.sin(theta)])
             for agent, theta in zip(self.agents, np.linspace(0, 2 * np.pi, NUM_DRONES, endpoint=False))
         }
+        self.drones_dist = {agent: 999.0 for agent in self.agents}
 
         observations = {agent: self._get_obs(agent) for agent in self.agents}
         return observations, {}
 
     def step(self, actions):
-        # Move missile towards base
-        direction = self.base_pos - self.missile_pos
-        distance = np.linalg.norm(direction)
-        if distance > 0:
-            direction /= distance
-        self.missile_velocity += direction * MAX_ACCELERATION
-        speed = np.linalg.norm(self.missile_velocity)
-        if speed > MAX_SPEED:
-            self.missile_velocity = self.missile_velocity / speed * MAX_SPEED
-        self.missile_pos += self.missile_velocity
+        # Updates missiles positions
+        for missile_id, missile_data in self.missiles_data.items():
+            if missile_data["neutralized"]:
+                continue
+            missile_pos = missile_data["missile_pos"]
+            missile_velocity = missile_data["missile_velocity"]
+            missile_acceleration = missile_data["missile_acceleration"]
+            # Move missile towards the base (or target)
+            direction = self.base_pos - missile_pos
+            distance = np.linalg.norm(direction)
+            if distance > 0:
+                direction /= distance  # Normalize direction vector
+                missile_velocity += direction * missile_acceleration
+            # Calculate the speed after applying the acceleration
+            speed = np.linalg.norm(missile_velocity)
+            # Update missile position based on its velocity
+            missile_pos += missile_velocity
+            self.missiles_data[missile_id]["missile_pos"] = missile_pos
+            self.missiles_data[missile_id]["missile_velocity"] = missile_velocity
 
-        # Move drones
+        # Updates drones positions
         for agent, action in actions.items():
             if agent in self.drones_pos:
                 self.drones_pos[agent] += action
@@ -99,30 +133,44 @@ class MissileDefenseEnv(MultiAgentEnv):
         dones = {agent: False for agent in self.agents}
         dones["__all__"] = False
 
+        # Check for missile hitting base
+        for missile_id, missile_data in self.missiles_data.items():
+            if np.linalg.norm(missile_data["missile_pos"] - self.base_pos) < BASE_SIZE / 2:
+                print("Base hit, game lost and terminate")
+                dones["__all__"] = True
+                rewards = {agent: BASE_HIT_REWARD for agent in self.agents}
+
         # If drone went out of bounds, stop providing its stuffs
         for agent in list(self.agents):
             if np.any(self.drones_pos[agent] < 0) or np.any(self.drones_pos[agent] > SCREEN_WIDTH):
                 rewards[agent] += OUT_OF_BOUND_REWARD
-                print(
-                    f"{agent} went out of bound at {self.drones_pos[agent]}, not providing any more observation")
+                print(f"{agent} went out of bound at {self.drones_pos[agent]}, not providing any more observation")
                 dones[agent] = True
                 self.agents.remove(agent)
-        if len(self.agents) == 0:
-            print("All drones went out of bound, terminate")
-            dones["__all__"] = True
-
-        # Check for missile hitting base
-        if np.linalg.norm(self.missile_pos - self.base_pos) < BASE_SIZE / 2:
-            print("Base hit, game lost and terminate")
-            dones["__all__"] = True
-            rewards = {agent: BASE_HIT_REWARD for agent in self.agents}
 
         # Check for drone intercepting missile, terminate
         for agent in list(self.agents):
-            if np.linalg.norm(self.drones_pos[agent] - self.missile_pos) < MISSILE_SIZE + DRONE_SIZE:
-                rewards[agent] += DRONE_HIT_REWARD
-                print("missile intercepted, threat eliminated")
-                dones["__all__"] = True
+            min_dist_to_missile = self.drones_dist[agent]
+            for missile_id, missile_data in self.missiles_data.items():
+                if missile_data["neutralized"]:
+                    continue
+                dist = np.linalg.norm(self.drones_pos[agent] - missile_data["missile_pos"])
+                if dist < min_dist_to_missile:
+                    min_dist_to_missile = dist
+                if dist < MISSILE_SIZE + DRONE_SIZE:
+                    rewards[agent] += DRONE_HIT_REWARD
+                    print(f"{agent} intercepted missile {missile_id}, threat eliminated")
+                    dones[agent] = True
+                    missile_data["neutralized"] = True
+                    if agent in self.agents:
+                        self.agents.remove(agent)
+            if min_dist_to_missile < self.drones_dist[agent]:
+                self.drones_dist[agent] = min_dist_to_missile
+                rewards[agent] += CLOSER_TO_MISSILE_REWARD
+
+        if len(self.agents) == 0:
+            print("All drones went out of bound, terminate")
+            dones["__all__"] = True
 
         # update the observations, dont include the drones that went out of bound, else the training will crash
         observations = {agent: self._get_obs(agent) for agent in self.agents}
@@ -137,21 +185,20 @@ class MissileDefenseEnv(MultiAgentEnv):
         return observations, rewards, dones, truncateds, infos
 
     def _get_obs(self, agent):
-        direction = self.missile_pos - self.drones_pos[agent]
-        distance = np.linalg.norm(direction)
-
-        if distance >= 0.0:
-            unit_vector = direction / distance
-            if np.any(unit_vector >= 1.0):
-                print("unit vector is greater than 1.0, shouldnt happen!!!!!")
-                print(f"unit_vector: {unit_vector}")
-                print(f"direction: {direction}, distance: {distance}")
-                print(
-                    f"missile_pos: {self.missile_pos}, drone_pos: {self.drones_pos[agent]}")
-        else:
-            # To avoid division by zero, shouldnt happen as will get terminate earlier
-            unit_vector = np.zeros(2)
-        return np.concatenate((unit_vector, [distance])).astype(np.float32)
+        obs = [self.drones_pos[agent][0], self.drones_pos[agent][1]]
+        for missile_id, missile_data in self.missiles_data.items():
+            if missile_data["neutralized"]:
+                obs.extend([0, 0, 0])
+            else:
+                missile_pos = missile_data["missile_pos"]
+                direction = missile_pos - self.drones_pos[agent]
+                distance = np.linalg.norm(direction)
+                if distance >= 0.0:
+                    unit_vector = direction / distance
+                else:
+                    unit_vector = np.zeros(2)
+                obs.extend(unit_vector.tolist() + [float(distance)])
+        return np.array(obs)
 
     def render(self):
         """
@@ -169,22 +216,21 @@ class MissileDefenseEnv(MultiAgentEnv):
             self.screen.blit(self.background_png, background_rect)
             base_rect = self.base_png.get_rect(center=self.base_pos)
             self.screen.blit(self.base_png, base_rect)
-            missile_direction = self.missile_velocity
-            angle = -np.degrees(np.arctan2(missile_direction[1], missile_direction[0]))
-            rotated_missile_img = pygame.transform.rotate(self.missile_png, angle)
-            missile_rect = rotated_missile_img.get_rect(center=self.missile_pos.astype(int))
-            self.screen.blit(rotated_missile_img, missile_rect)
+            for missile_data in self.missiles_data.values():
+                missile_direction = missile_data["missile_velocity"]
+                angle = -np.degrees(np.arctan2(missile_direction[1], missile_direction[0]))
+                rotated_missile_img = pygame.transform.rotate(self.missile_png, angle)
+                missile_rect = rotated_missile_img.get_rect(center=missile_data["missile_pos"].astype(int))
+                self.screen.blit(rotated_missile_img, missile_rect)
             for drone_pos in self.drones_pos.values():
                 drone_rect = self.drone_png.get_rect(center=drone_pos.astype(int))
                 self.screen.blit(self.drone_png, drone_rect)
         else:
-            pygame.draw.rect(self.screen, BLUE, (*self.base_pos -
-                            BASE_SIZE // 2, BASE_SIZE, BASE_SIZE))
-            pygame.draw.circle(
-                self.screen, RED, self.missile_pos.astype(int), MISSILE_SIZE)
+            pygame.draw.rect(self.screen, BLUE, (*self.base_pos - BASE_SIZE // 2, BASE_SIZE, BASE_SIZE))
+            for missile_data in self.missiles_data.values():
+                pygame.draw.circle(self.screen, RED, missile_data["missile_pos"], MISSILE_SIZE)
             for drone_pos in self.drones_pos.values():
-                pygame.draw.circle(self.screen, GREEN,
-                                drone_pos.astype(int), DRONE_SIZE)
+                pygame.draw.circle(self.screen, GREEN, drone_pos.astype(int), DRONE_SIZE)
         pygame.display.flip()
         # the higher the number, the faster the simulation
         self.clock.tick(600)
@@ -198,12 +244,10 @@ if __name__ == "__main__":
     env = MissileDefenseEnv(render=True, realistic_render=True)
     obs = env.reset()
     done = False
-    actions = {"drone_0": np.array([0.1, 0.1]), "drone_1": np.array(
-        [-0.1, -0.1]), "drone_2": np.array([0.0, 0.0])}
+    actions = {"drone_0": np.array([0.1, 0.1]), "drone_1": np.array([-0.1, -0.1]), "drone_2": np.array([0.0, 0.0])}
     obs, rewards, terminateds, truncateds, infos = env.step(actions)
     while not done:
-        actions = {"drone_0": np.array([0.1, 0.1]), "drone_1": np.array(
-            [-0.1, -0.1]), "drone_2": np.array([0.0, 0.0])}
+        actions = {"drone_0": np.array([0.1, 0.1]), "drone_1": np.array([-0.1, -0.1]), "drone_2": np.array([0.0, 0.0])}
         obs, rewards, dones, truncateds, infos = env.step(actions)
         done = dones["__all__"]
     env.close()

--- a/requirements.yml
+++ b/requirements.yml
@@ -9,3 +9,4 @@ dependencies:
     - torch
     - pygame
     - ray[rllib,tune,serve]
+    - aiohttp_cors==0.7.0

--- a/testing_agent.py
+++ b/testing_agent.py
@@ -39,14 +39,5 @@ while True:
 
         observations, rewards, dones, truncateds, infos = env.step(actions)
         done = dones["__all__"]
-        # print(f"Actions: {actions}")
-        # print(f"Rewards: {rewards}")
-        # print(f"Dones: {dones}")
-        # print(len(observations))
-        # for key,value in observations.items():
-        #     print(f"{key}: {value}")
-        # for key, value in observations.items():
-        #     if value.shape[0] != 33:        #         print("error!")
-            # print(f"{key}: {value.shape}")  # or len(value) 
 
 env.close()

--- a/testing_agent.py
+++ b/testing_agent.py
@@ -38,8 +38,13 @@ while True:
 
         observations, rewards, dones, truncateds, infos = env.step(actions)
         done = dones["__all__"]
-        print(f"Actions: {actions}")
-        print(f"Rewards: {rewards}")
-        print(f"Dones: {dones}")
+        # print(f"Actions: {actions}")
+        # print(f"Rewards: {rewards}")
+        # print(f"Dones: {dones}")
+        # print(len(observations))
+        for key, value in observations.items():
+            if value.shape[0] != 11:
+                print("error!")
+            # print(f"{key}: {value.shape}")  # or len(value) 
 
 env.close()

--- a/testing_agent.py
+++ b/testing_agent.py
@@ -10,7 +10,8 @@ register_env(env_name, lambda config: MissileDefenseEnv(config, render=False))
 
 # Define the checkpoint path (update this to your actual checkpoint location)
 pwd = os.getcwd()
-checkpoint_path = os.path.join(pwd, "sample_trained_model/checkpoint_000000")
+model_path = input("Enter your model path")
+checkpoint_path = os.path.join(pwd, model_path if model_path else "sample_trained_model/checkpoint_000000")
 
 # Load the trained model
 config = (
@@ -23,7 +24,7 @@ config = (
 algo = PPO.from_checkpoint(checkpoint_path)
 
 # Create the environment for testing
-env = MissileDefenseEnv(render=True, realistic_render=True)
+env = MissileDefenseEnv(render=True, realistic_render=True, test_level=3)
 
 while True:
     # Run a test episode
@@ -42,9 +43,10 @@ while True:
         # print(f"Rewards: {rewards}")
         # print(f"Dones: {dones}")
         # print(len(observations))
-        for key, value in observations.items():
-            if value.shape[0] != 11:
-                print("error!")
+        # for key,value in observations.items():
+        #     print(f"{key}: {value}")
+        # for key, value in observations.items():
+        #     if value.shape[0] != 33:        #         print("error!")
             # print(f"{key}: {value.shape}")  # or len(value) 
 
 env.close()

--- a/training_agent.py
+++ b/training_agent.py
@@ -10,14 +10,14 @@ checkpoint_path = os.path.join(cwd, "models")
 
 # Register the custom environment
 env_name = "missile_defense_env"
-register_env(env_name, lambda config: MissileDefenseEnv(config, render=False))
+register_env(env_name, lambda config: MissileDefenseEnv(config, render=False, realistic_render=False))
 
 
 # Configure MAPPO with shared policies
 config = (
     PPOConfig()
     .environment(env=env_name)
-    .rollouts(num_rollout_workers=1)
+    .rollouts(num_rollout_workers=8)
     .training(
         lr=5e-4,  # Learning rate
         gamma=0.99,  # Discount factor
@@ -44,10 +44,10 @@ tune.Tuner(
     "PPO",
     param_space=config.to_dict(),
     run_config=air.RunConfig(
-        stop={"episodes_total": 2000},
+        stop={"training_iteration": 3001},
         storage_path=checkpoint_path,  # Specify the custom save directory
         checkpoint_config=air.CheckpointConfig(
-            checkpoint_frequency=3,  # Save a checkpoint every 10 training iterations
+            checkpoint_frequency=50,  # Save a checkpoint every 10 training iterations
             checkpoint_at_end=True,   # Also save at the end of training
         ),
     ),

--- a/training_agent.py
+++ b/training_agent.py
@@ -44,7 +44,7 @@ tune.Tuner(
     "PPO",
     param_space=config.to_dict(),
     run_config=air.RunConfig(
-        stop={"training_iteration": 3001},
+        stop={"training_iteration": 100000},
         storage_path=checkpoint_path,  # Specify the custom save directory
         checkpoint_config=air.CheckpointConfig(
             checkpoint_frequency=50,  # Save a checkpoint every 10 training iterations


### PR DESCRIPTION
1. removed the "three slots" missile states in each agent's observations, we let the gym to act as "control center" to assign the nearest missile to the agent, so agent only have one set of missile states
2. Added new state for missle, distance between missile and base. And smaller distance penalizes agent more
3. acceleration and velocity scaled rewards, if the acceleration and velocity align towards the unit vector direction from agent to missile, get more rewards
4. approaching boundary penalty gets a scaled penalty before the final out of bound penalty
5. The state spaces for agents still only observes itself, but I left a commented section for adding other agents' states in the observations
6. Gym is able to init with level and before running the testing_agent.py, it prompts input for the model path. 
7. Some minor renaming of constants.