### PR TITLE
Staging 250326

### DIFF
--- a/testing_agent.py
+++ b/testing_agent.py
@@ -39,14 +39,5 @@ while True:
 
         observations, rewards, dones, truncateds, infos = env.step(actions)
         done = dones["__all__"]
-        # print(f"Actions: {actions}")
-        # print(f"Rewards: {rewards}")
-        # print(f"Dones: {dones}")
-        # print(len(observations))
-        # for key,value in observations.items():
-        #     print(f"{key}: {value}")
-        # for key, value in observations.items():
-        #     if value.shape[0] != 33:        #         print("error!")
-            # print(f"{key}: {value.shape}")  # or len(value) 
 
 env.close()

--- a/testing_agent.py
+++ b/testing_agent.py
@@ -10,7 +10,8 @@ register_env(env_name, lambda config: MissileDefenseEnv(config, render=False))
 
 # Define the checkpoint path (update this to your actual checkpoint location)
 pwd = os.getcwd()
-checkpoint_path = os.path.join(pwd, "sample_trained_model/checkpoint_000000")
+model_path = input("Enter your model path")
+checkpoint_path = os.path.join(pwd, model_path if model_path else "sample_trained_model/checkpoint_000000")
 
 # Load the trained model
 config = (
@@ -23,7 +24,7 @@ config = (
 algo = PPO.from_checkpoint(checkpoint_path)
 
 # Create the environment for testing
-env = MissileDefenseEnv(render=True, realistic_render=True)
+env = MissileDefenseEnv(render=True, realistic_render=True, test_level=3)
 
 while True:
     # Run a test episode
@@ -42,9 +43,10 @@ while True:
         # print(f"Rewards: {rewards}")
         # print(f"Dones: {dones}")
         # print(len(observations))
-        for key, value in observations.items():
-            if value.shape[0] != 11:
-                print("error!")
+        # for key,value in observations.items():
+        #     print(f"{key}: {value}")
+        # for key, value in observations.items():
+        #     if value.shape[0] != 33:        #         print("error!")
             # print(f"{key}: {value.shape}")  # or len(value) 
 
 env.close()

--- a/training_agent.py
+++ b/training_agent.py
@@ -44,7 +44,7 @@ tune.Tuner(
     "PPO",
     param_space=config.to_dict(),
     run_config=air.RunConfig(
-        stop={"training_iteration": 3001},
+        stop={"training_iteration": 100000},
         storage_path=checkpoint_path,  # Specify the custom save directory
         checkpoint_config=air.CheckpointConfig(
             checkpoint_frequency=50,  # Save a checkpoint every 10 training iterations


### PR DESCRIPTION
1. removed the "three slots" missile states in each agent's observations, we let the gym to act as "control center" to assign the nearest missile to the agent, so agent only have one set of missile states
2. Added new state for missle, distance between missile and base. And smaller distance penalizes agent more
3. acceleration and velocity scaled rewards, if the acceleration and velocity align towards the unit vector direction from agent to missile, get more rewards
4. approaching boundary penalty gets a scaled penalty before the final out of bound penalty
5. The state spaces for agents still only observes itself, but I left a commented section for adding other agents' states in the observations
6. Gym is able to init with level and before running the testing_agent.py, it prompts input for the model path. 
7. Some minor renaming of constants.